### PR TITLE
Filter PII rather than removing headers entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # CHANGELOG
 
 ## Unreleased
-- Change default PII sanitization to redact value only instead of removing both key as well
-- Moved default PII sanitization headers into options as 'default_pii_headers'
 
+- Make the HTTP headers sanitizable in the `RequestIntegration` integration instead of removing them entirely (#1161)
 - Deprecate the `logger` option (#1167)
 - Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
 - Deprecate the `tags` option, see the [docs](https://docs.sentry.io/platforms/php/guides/laravel/enriching-events/tags/) for other ways to set tags (#1174)
 
 ## 3.1.2 (2021-01-08)
+
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
 - Fix the `logger` option not being applied to the event object (#1165)
 - Fix a bug that made some event attributes being overwritten by option config values when calling `captureEvent()` (#1148)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Deprecate the `logger` option (#1167)
+- Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
 
 ## 3.1.2 (2021-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deprecate the `logger` option (#1167)
 - Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
+- Deprecate the `tags` option, see the [docs](https://docs.sentry.io/platforms/php/guides/laravel/enriching-events/tags/) for other ways to set tags (#1174)
 
 ## 3.1.2 (2021-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Deprecate the `logger` option (#1167)
+
 ## 3.1.2 (2021-01-08)
 
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # CHANGELOG
 
 ## Unreleased
+- Change default PII sanitization to redact value only instead of removing both key as well
+- Moved default PII sanitization headers into options as 'default_pii_headers'
 
 - Deprecate the `logger` option (#1167)
 - Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
 - Deprecate the `tags` option, see the [docs](https://docs.sentry.io/platforms/php/guides/laravel/enriching-events/tags/) for other ways to set tags (#1174)
 
 ## 3.1.2 (2021-01-08)
-
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
 - Fix the `logger` option not being applied to the event object (#1165)
 - Fix a bug that made some event attributes being overwritten by option config values when calling `captureEvent()` (#1148)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,77 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Sentry\\\\Client\\:\\:getIntegration\\(\\) should return T of Sentry\\\\Integration\\\\IntegrationInterface\\|null but returns Sentry\\\\Integration\\\\IntegrationInterface\\|null\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Offset 'scheme' does not exist on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
+			count: 1
+			path: src/Dsn.php
+
+		-
+			message: "#^Offset 'path' does not exist on array\\(\\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string, 'scheme' \\=\\> 'http'\\|'https'\\)\\.$#"
+			count: 4
+			path: src/Dsn.php
+
+		-
+			message: "#^Offset 'host' does not exist on array\\(\\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string, 'scheme' \\=\\> 'http'\\|'https'\\)\\.$#"
+			count: 1
+			path: src/Dsn.php
+
+		-
+			message: "#^Offset 'user' does not exist on array\\('scheme' \\=\\> 'http'\\|'https', \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
+			count: 1
+			path: src/Dsn.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: src/EventHint.php
+
+		-
+			message: "#^Call to static method create\\(\\) on an unknown class Symfony\\\\Component\\\\HttpClient\\\\HttpClient\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Access to constant TIMEOUT on an unknown class GuzzleHttp\\\\RequestOptions\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Access to constant CONNECT_TIMEOUT on an unknown class GuzzleHttp\\\\RequestOptions\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Access to constant PROXY on an unknown class GuzzleHttp\\\\RequestOptions\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Method Sentry\\\\Monolog\\\\Handler\\:\\:write\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Monolog/Handler.php
+
+		-
+			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Serializer/AbstractSerializer.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/State/HubAdapter.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$customSamplingContext$#"
+			count: 1
+			path: src/State/HubInterface.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/functions.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
+			count: 3
+			path: src/ClientInterface.php
+
+		-
 			message: "#^Offset 'scheme' does not exist on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
 			count: 1
 			path: src/Dsn.php
@@ -61,14 +66,49 @@ parameters:
 			path: src/Serializer/AbstractSerializer.php
 
 		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureMessage\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureException\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureLastError\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: src/State/HubAdapter.php
 
 		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
+			count: 3
+			path: src/State/HubInterface.php
+
+		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$customSamplingContext$#"
 			count: 1
 			path: src/State/HubInterface.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureMessage\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureLastError\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/functions.php
 
 		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,41 +1,12 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     tipsOfTheDay: false
     treatPhpDocTypesAsCertain: false
     level: 8
     paths:
         - src
-    ignoreErrors:
-        - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
-        -
-            message: '/^Access to constant (?:PROXY|TIMEOUT|CONNECT_TIMEOUT) on an unknown class GuzzleHttp\\RequestOptions\.$/'
-            path: src/HttpClient/HttpClientFactory.php
-        -
-            message: '/^Call to static method create\(\) on an unknown class Symfony\\Component\\HttpClient\\HttpClient\.$/'
-            path: src/HttpClient/HttpClientFactory.php
-        -
-            message: "/^Offset 'scheme' does not exist on array\\(\\?'scheme' => string, \\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string\\)\\.$/"
-            path: src/Dsn.php
-        -
-            message: "/^Offset 'path' does not exist on array\\(\\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string, 'scheme' => 'http'|'https'\\)\\.$/"
-            path: src/Dsn.php
-        -
-            message: "/^Offset 'user' does not exist on array\\('scheme' => 'http'\\|'https', \\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string\\)\\.$/"
-            path: src/Dsn.php
-        -
-            message: '/^Method Sentry\\Monolog\\Handler::write\(\) has parameter \$record with no value type specified in iterable type array\.$/'
-            path: src/Monolog/Handler.php
-        -
-            message: '/^Method Sentry\\Client::getIntegration\(\) should return T of Sentry\\Integration\\IntegrationInterface\|null but returns Sentry\\Integration\\IntegrationInterface\|null\.$/'
-            path: src/Client.php
-        -
-            message: "/^PHPDoc tag @param references unknown parameter: \\$customSamplingContext$/"
-            path: src/State/HubInterface.php
-        -
-            message: '/^Method Sentry\\State\\HubInterface::startTransaction\(\) invoked with 2 parameters, 1 required\.$/'
-            path: src/State/HubAdapter.php
-        -
-            message: '/^Method Sentry\\State\\HubInterface::startTransaction\(\) invoked with 2 parameters, 1 required\.$/'
-            path: src/functions.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,7 @@ final class Client implements ClientInterface
 
         $event->setSdkIdentifier($this->sdkIdentifier);
         $event->setSdkVersion($this->sdkVersion);
-        $event->setTags(array_merge($this->options->getTags(), $event->getTags()));
+        $event->setTags(array_merge($this->options->getTags(false), $event->getTags()));
 
         if (null === $event->getServerName()) {
             $event->setServerName($this->options->getServerName());

--- a/src/Client.php
+++ b/src/Client.php
@@ -109,7 +109,7 @@ final class Client implements ClientInterface
         $this->representationSerializer = $representationSerializer ?? new RepresentationSerializer($this->options);
         $this->stacktraceBuilder = new StacktraceBuilder($options, $this->representationSerializer);
         $this->sdkIdentifier = $sdkIdentifier ?? self::SDK_IDENTIFIER;
-        $this->sdkVersion = $sdkVersion ?? PrettyVersions::getVersion(PrettyVersions::getRootPackageName())->getPrettyVersion();
+        $this->sdkVersion = $sdkVersion ?? PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
     }
 
     /**
@@ -294,7 +294,7 @@ final class Client implements ClientInterface
         }
 
         $event->setStacktrace($this->stacktraceBuilder->buildFromBacktrace(
-            debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS),
+            debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS),
             __FILE__,
             __LINE__ - 3
         ));

--- a/src/Client.php
+++ b/src/Client.php
@@ -242,7 +242,7 @@ final class Client implements ClientInterface
         }
 
         if (null === $event->getLogger()) {
-            $event->setLogger($this->options->getLogger());
+            $event->setLogger($this->options->getLogger(false));
         }
 
         $isTransaction = EventType::transaction() === $event->getType();

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -23,26 +23,29 @@ interface ClientInterface
     /**
      * Logs a message.
      *
-     * @param string     $message The message (primary description) for the event
-     * @param Severity   $level   The level of the message to be sent
-     * @param Scope|null $scope   An optional scope keeping the state
+     * @param string         $message The message (primary description) for the event
+     * @param Severity|null  $level   The level of the message to be sent
+     * @param Scope|null     $scope   An optional scope keeping the state
+     * @param EventHint|null $hint    Object that can contain additional information about the event
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?EventId;
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Logs an exception.
      *
-     * @param \Throwable $exception The exception object
-     * @param Scope|null $scope     An optional scope keeping the state
+     * @param \Throwable     $exception The exception object
+     * @param Scope|null     $scope     An optional scope keeping the state
+     * @param EventHint|null $hint      Object that can contain additional information about the event
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null): ?EventId;
+    public function captureException(\Throwable $exception, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Logs the most recent error (obtained with {@link error_get_last}).
      *
-     * @param Scope|null $scope An optional scope keeping the state
+     * @param Scope|null     $scope An optional scope keeping the state
+     * @param EventHint|null $hint  Object that can contain additional information about the event
      */
-    public function captureLastError(?Scope $scope = null): ?EventId;
+    public function captureLastError(?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures a new event using the provided data.

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -91,21 +91,21 @@ final class ErrorHandler
      * @var array List of error levels and their description
      */
     private const ERROR_LEVELS_DESCRIPTION = [
-        E_DEPRECATED => 'Deprecated',
-        E_USER_DEPRECATED => 'User Deprecated',
-        E_NOTICE => 'Notice',
-        E_USER_NOTICE => 'User Notice',
-        E_STRICT => 'Runtime Notice',
-        E_WARNING => 'Warning',
-        E_USER_WARNING => 'User Warning',
-        E_COMPILE_WARNING => 'Compile Warning',
-        E_CORE_WARNING => 'Core Warning',
-        E_USER_ERROR => 'User Error',
-        E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
-        E_COMPILE_ERROR => 'Compile Error',
-        E_PARSE => 'Parse Error',
-        E_ERROR => 'Error',
-        E_CORE_ERROR => 'Core Error',
+        \E_DEPRECATED => 'Deprecated',
+        \E_USER_DEPRECATED => 'User Deprecated',
+        \E_NOTICE => 'Notice',
+        \E_USER_NOTICE => 'User Notice',
+        \E_STRICT => 'Runtime Notice',
+        \E_WARNING => 'Warning',
+        \E_USER_WARNING => 'User Warning',
+        \E_COMPILE_WARNING => 'Compile Warning',
+        \E_CORE_WARNING => 'Core Warning',
+        \E_USER_ERROR => 'User Error',
+        \E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+        \E_COMPILE_ERROR => 'Compile Error',
+        \E_PARSE => 'Parse Error',
+        \E_ERROR => 'Error',
+        \E_CORE_ERROR => 'Core Error',
     ];
 
     /**
@@ -145,7 +145,7 @@ final class ErrorHandler
             // first call to the set_error_handler method would cause the PHP
             // bug https://bugs.php.net/63206 if the handler is not the first
             // one in the chain of handlers
-            set_error_handler($errorHandlerCallback, E_ALL);
+            set_error_handler($errorHandlerCallback, \E_ALL);
         }
 
         return self::$handlerInstance;
@@ -300,7 +300,7 @@ final class ErrorHandler
         self::$reservedMemory = null;
         $error = error_get_last();
 
-        if (!empty($error) && $error['type'] & (E_ERROR | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING)) {
+        if (!empty($error) && $error['type'] & (\E_ERROR | \E_PARSE | \E_CORE_ERROR | \E_CORE_WARNING | \E_COMPILE_ERROR | \E_COMPILE_WARNING)) {
             $errorAsException = new FatalErrorException(self::ERROR_LEVELS_DESCRIPTION[$error['type']] . ': ' . $error['message'], 0, $error['type'], $error['file'], $error['line']);
 
             $this->exceptionReflection->setValue($errorAsException, []);

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -34,7 +34,7 @@ final class EventHint
      * Create a EventHint instance from an array of values.
      *
      * @psalm-param array{
-     *     exception?: \Throwable,
+     *     exception?: \Throwable|null,
      *     stacktrace?: Stacktrace|null,
      *     extra?: array<string, mixed>
      * } $hintData
@@ -42,14 +42,25 @@ final class EventHint
     public static function fromArray(array $hintData): self
     {
         $hint = new self();
+        $exception = $hintData['exception'] ?? null;
+        $stacktrace = $hintData['stacktrace'] ?? null;
+        $extra = $hintData['extra'] ?? [];
 
-        foreach ($hintData as $hintKey => $hintValue) {
-            if (!property_exists($hint, $hintKey)) {
-                throw new \InvalidArgumentException(sprintf('There is no EventHint attribute called "%s".', $hintKey));
-            }
-
-            $hint->{$hintKey} = $hintValue;
+        if (null !== $exception && !$exception instanceof \Throwable) {
+            throw new \InvalidArgumentException(sprintf('The value of the "exception" field must be an instance of a class implementing the "%s" interface. Got: "%s".', \Throwable::class, get_debug_type($exception)));
         }
+
+        if (null !== $stacktrace && !$stacktrace instanceof Stacktrace) {
+            throw new \InvalidArgumentException(sprintf('The value of the "stacktrace" field must be an instance of the "%s" class. Got: "%s".', Stacktrace::class, get_debug_type($stacktrace)));
+        }
+
+        if (!\is_array($extra)) {
+            throw new \InvalidArgumentException(sprintf('The value of the "extra" field must be an array. Got: "%s".', get_debug_type($extra)));
+        }
+
+        $hint->exception = $exception;
+        $hint->stacktrace = $stacktrace;
+        $hint->extra = $extra;
 
         return $hint;
     }

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -142,12 +142,12 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 $httpClient = GuzzleHttpClient::createWithConfig($guzzleConfig);
             } elseif (class_exists(CurlHttpClient::class)) {
                 $curlConfig = [
-                    CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
-                    CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                    \CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
+                    \CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
                 ];
 
                 if (null !== $options->getHttpProxy()) {
-                    $curlConfig[CURLOPT_PROXY] = $options->getHttpProxy();
+                    $curlConfig[\CURLOPT_PROXY] = $options->getHttpProxy();
                 }
 
                 /** @psalm-suppress InvalidPropertyAssignmentValue */

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -50,7 +50,7 @@ final class GzipEncoderPlugin implements PluginInterface
 
         // Instead of using a stream filter we have to compress the whole request
         // body in one go to work around a PHP bug. See https://github.com/getsentry/sentry-php/pull/877
-        $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
+        $encodedBody = gzcompress($requestBody->getContents(), -1, \ZLIB_ENCODING_GZIP);
 
         if (false === $encodedBody) {
             throw new \RuntimeException('Failed to GZIP-encode the request body.');

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -144,13 +144,20 @@ final class RequestIntegration implements IntegrationInterface
     {
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
 
-        return array_filter(
-            $headers,
-            static function (string $key) use ($keysToRemove): bool {
-                return !\in_array(strtolower($key), $keysToRemove, true);
-            },
-            \ARRAY_FILTER_USE_KEY
-        );
+        $newHeaders = $headers;
+        foreach ($newHeaders as $key => $value) {
+            if (in_array(strtolower($key), $keysToRemove)) {
+                if (is_array($value)) {
+                    foreach ($value as $subKey => $subValue) {
+                        $newHeaders[$key][$subKey] = '[Filtered]';
+                    }
+                } else {
+                    $newHeaders[$key] = '[Filtered]';
+                }
+            }
+        }
+
+        return $newHeaders;
     }
 
     /**

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -144,16 +144,15 @@ final class RequestIntegration implements IntegrationInterface
     {
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
 
-        $newHeaders = $headers;
-        foreach ($newHeaders as $key => $value) {
+        foreach ($headers as $key => $value) {
             if (\in_array(strtolower($key), $keysToRemove, true)) {
                 foreach ($value as $subKey => $subValue) {
-                    $newHeaders[$key][$subKey] = '[Filtered]';
+                    $headers[$key][$subKey] = '[Filtered]';
                 }
             }
         }
 
-        return $newHeaders;
+        return $headers;
     }
 
     /**

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -149,7 +149,7 @@ final class RequestIntegration implements IntegrationInterface
             static function (string $key) use ($keysToRemove): bool {
                 return !\in_array(strtolower($key), $keysToRemove, true);
             },
-            ARRAY_FILTER_USE_KEY
+            \ARRAY_FILTER_USE_KEY
         );
     }
 

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -14,6 +14,8 @@ use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Sentry\UserDataBag;
 use Sentry\Util\JSON;
+use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This integration collects information from the request and attaches them to
@@ -49,18 +51,45 @@ final class RequestIntegration implements IntegrationInterface
     ];
 
     /**
+     * This constant defines the default list of headers that may contain
+     * sensitive data and that will be sanitized if sending PII is disabled.
+     */
+    private const DEFAULT_SENSITIVE_HEADERS = [
+        'Authorization',
+        'Cookie',
+        'Set-Cookie',
+        'X-Forwarded-For',
+        'X-Real-IP',
+    ];
+
+    /**
      * @var RequestFetcherInterface PSR-7 request fetcher
      */
     private $requestFetcher;
 
     /**
+     * @var array<string, mixed> The options
+     */
+    private $options;
+
+    /**
      * Constructor.
      *
      * @param RequestFetcherInterface|null $requestFetcher PSR-7 request fetcher
+     * @param array<string, mixed>         $options        The options
+     *
+     * @psalm-param array{
+     *     pii_sanitize_headers?: string[]
+     * } $options
      */
-    public function __construct(?RequestFetcherInterface $requestFetcher = null)
+    public function __construct(?RequestFetcherInterface $requestFetcher = null, array $options = [])
     {
+        $resolver = new OptionsResolver();
+
+        $this->configureOptions($resolver);
+
         $this->requestFetcher = $requestFetcher ?? new RequestFetcher();
+        $this->options = $resolver->resolve($options);
     }
 
     /**
@@ -121,7 +150,7 @@ final class RequestIntegration implements IntegrationInterface
             $requestData['cookies'] = $request->getCookieParams();
             $requestData['headers'] = $request->getHeaders();
         } else {
-            $requestData['headers'] = $this->removePiiFromHeaders($options, $request->getHeaders());
+            $requestData['headers'] = $this->sanitizeHeaders($request->getHeaders());
         }
 
         $requestBody = $this->captureRequestBody($options, $request);
@@ -136,20 +165,19 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Removes headers containing potential PII.
      *
-     * @param Options                           $options The options of the client
-     * @param array<string, array<int, string>> $headers Array containing request headers
+     * @param array<string, string[]> $headers Array containing request headers
      *
-     * @return array<string, array<int, string>>
+     * @return array<string, string[]>
      */
-    private function removePiiFromHeaders(Options $options, array $headers): array
+    private function sanitizeHeaders(array $headers): array
     {
-        $keysToRemove = $options->getDefaultPIIHeaders();
+        foreach ($headers as $name => $values) {
+            if (!\in_array(strtolower($name), $this->options['pii_sanitize_headers'], true)) {
+                continue;
+            }
 
-        foreach ($headers as $key => $value) {
-            if (\in_array(strtolower($key), $keysToRemove, true)) {
-                foreach ($value as $subKey => $subValue) {
-                    $headers[$key][$subKey] = '[Filtered]';
-                }
+            foreach ($values as $headerLine => $headerValue) {
+                $headers[$name][$headerLine] = '[Filtered]';
             }
         }
 
@@ -247,5 +275,19 @@ final class RequestIntegration implements IntegrationInterface
         }
 
         return true;
+    }
+
+    /**
+     * Configures the options of the client.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    private function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('pii_sanitize_headers', self::DEFAULT_SENSITIVE_HEADERS);
+        $resolver->setAllowedTypes('pii_sanitize_headers', 'string[]');
+        $resolver->setNormalizer('pii_sanitize_headers', static function (SymfonyOptions $options, array $value): array {
+            return array_map('strtolower', $value);
+        });
     }
 }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -121,7 +121,7 @@ final class RequestIntegration implements IntegrationInterface
             $requestData['cookies'] = $request->getCookieParams();
             $requestData['headers'] = $request->getHeaders();
         } else {
-            $requestData['headers'] = $this->removePiiFromHeaders($request->getHeaders());
+            $requestData['headers'] = $this->removePiiFromHeaders($options, $request->getHeaders());
         }
 
         $requestBody = $this->captureRequestBody($options, $request);
@@ -136,13 +136,14 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Removes headers containing potential PII.
      *
+     * @param Options $options The options of the client
      * @param array<string, array<int, string>> $headers Array containing request headers
      *
      * @return array<string, array<int, string>>
      */
-    private function removePiiFromHeaders(array $headers): array
+    private function removePiiFromHeaders(Options $options, array $headers): array
     {
-        $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
+        $keysToRemove = $options->getDefaultPIIHeaders();
 
         foreach ($headers as $key => $value) {
             if (\in_array(strtolower($key), $keysToRemove, true)) {

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -136,7 +136,7 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Removes headers containing potential PII.
      *
-     * @param Options $options The options of the client
+     * @param Options                           $options The options of the client
      * @param array<string, array<int, string>> $headers Array containing request headers
      *
      * @return array<string, array<int, string>>

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -146,7 +146,7 @@ final class RequestIntegration implements IntegrationInterface
 
         $newHeaders = $headers;
         foreach ($newHeaders as $key => $value) {
-            if (\in_array(strtolower($key), $keysToRemove)) {
+            if (\in_array(strtolower($key), $keysToRemove, true)) {
                 foreach ($value as $subKey => $subValue) {
                     $newHeaders[$key][$subKey] = '[Filtered]';
                 }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -146,13 +146,9 @@ final class RequestIntegration implements IntegrationInterface
 
         $newHeaders = $headers;
         foreach ($newHeaders as $key => $value) {
-            if (in_array(strtolower($key), $keysToRemove)) {
-                if (is_array($value)) {
-                    foreach ($value as $subKey => $subValue) {
-                        $newHeaders[$key][$subKey] = '[Filtered]';
-                    }
-                } else {
-                    $newHeaders[$key] = '[Filtered]';
+            if (\in_array(strtolower($key), $keysToRemove)) {
+                foreach ($value as $subKey => $subValue) {
+                    $newHeaders[$key][$subKey] = '[Filtered]';
                 }
             }
         }

--- a/src/Options.php
+++ b/src/Options.php
@@ -688,7 +688,7 @@ final class Options
     }
 
     /**
-     * Array of headers to be sanitized as PII
+     * Array of headers to be sanitized as PII.
      *
      * @return array<string>
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -680,7 +680,7 @@ final class Options
             'integrations' => [],
             'default_integrations' => true,
             'send_attempts' => 3,
-            'prefixes' => array_filter(explode(PATH_SEPARATOR, get_include_path() ?: '')),
+            'prefixes' => array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: '')),
             'sample_rate' => 1,
             'traces_sample_rate' => 0,
             'traces_sampler' => null,

--- a/src/Options.php
+++ b/src/Options.php
@@ -687,34 +687,6 @@ final class Options
     }
 
     /**
-     * Array of headers to be sanitized as PII.
-     *
-     * @return array<string>
-     */
-    public function getDefaultPIIHeaders()
-    {
-        return $this->options['default_pii_headers'];
-    }
-
-    /**
-     * Set the headers to be sanitized when 'send_default_pii' is false.
-     *
-     * @param array<string> $headers
-     */
-    public function setDefaultPIIHeaders(array $headers): void
-    {
-        foreach ($headers as $header) {
-            if (!\is_string($header)) {
-                throw new \InvalidArgumentException('Headers must be strings.');
-            }
-        }
-
-        $options = array_merge($this->options, ['default_pii_headers' => $headers]);
-
-        $this->options = $this->resolver->resolve($options);
-    }
-
-    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -757,7 +729,6 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
-            'default_pii_headers' => ['authorization', 'cookie', 'set-cookie', 'remote_addr'],
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');

--- a/src/Options.php
+++ b/src/Options.php
@@ -276,7 +276,7 @@ final class Options
     public function getLogger(/*bool $triggerDeprecation = true*/): string
     {
         if (0 === \func_num_args() || false !== func_get_arg(0)) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), \E_USER_DEPRECATED);
         }
 
         return $this->options['logger'];
@@ -291,7 +291,7 @@ final class Options
      */
     public function setLogger(string $logger): void
     {
-        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), \E_USER_DEPRECATED);
 
         $options = array_merge($this->options, ['logger' => $logger]);
 
@@ -772,7 +772,7 @@ final class Options
 
         $resolver->setNormalizer('logger', function (SymfonyOptions $options, ?string $value): ?string {
             if ('php' !== $value) {
-                @trigger_error('The option "logger" is deprecated.', E_USER_DEPRECATED);
+                @trigger_error('The option "logger" is deprecated.', \E_USER_DEPRECATED);
             }
 
             return $value;

--- a/src/Options.php
+++ b/src/Options.php
@@ -270,9 +270,15 @@ final class Options
 
     /**
      * Gets the logger used by Sentry.
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
-    public function getLogger(): string
+    public function getLogger(/*bool $triggerDeprecation = true*/): string
     {
+        if (0 === \func_num_args() || false !== func_get_arg(0)) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         return $this->options['logger'];
     }
 
@@ -280,9 +286,13 @@ final class Options
      * Sets the logger used by Sentry.
      *
      * @param string $logger The logger
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
     public function setLogger(string $logger): void
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+
         $options = array_merge($this->options, ['logger' => $logger]);
 
         $this->options = $this->resolver->resolve($options);
@@ -722,7 +732,7 @@ final class Options
         $resolver->setAllowedTypes('environment', ['null', 'string']);
         $resolver->setAllowedTypes('in_app_exclude', 'string[]');
         $resolver->setAllowedTypes('in_app_include', 'string[]');
-        $resolver->setAllowedTypes('logger', 'string');
+        $resolver->setAllowedTypes('logger', ['null', 'string']);
         $resolver->setAllowedTypes('release', ['null', 'string']);
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');
@@ -758,6 +768,14 @@ final class Options
 
         $resolver->setNormalizer('in_app_include', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);
+        });
+
+        $resolver->setNormalizer('logger', function (SymfonyOptions $options, ?string $value): ?string {
+            if ('php' !== $value) {
+                @trigger_error('The option "logger" is deprecated.', E_USER_DEPRECATED);
+            }
+
+            return $value;
         });
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -378,9 +378,15 @@ final class Options
      * Gets a list of default tags for events.
      *
      * @return array<string, string>
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
-    public function getTags(): array
+    public function getTags(/*bool $triggerDeprecation = true*/): array
     {
+        if (0 === \func_num_args() || false !== func_get_arg(0)) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), \E_USER_DEPRECATED);
+        }
+
         return $this->options['tags'];
     }
 
@@ -388,9 +394,13 @@ final class Options
      * Sets a list of default tags for events.
      *
      * @param array<string, string> $tags A list of tags
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
     public function setTags(array $tags): void
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.', __METHOD__), \E_USER_DEPRECATED);
+
         $options = array_merge($this->options, ['tags' => $tags]);
 
         $this->options = $this->resolver->resolve($options);
@@ -757,6 +767,13 @@ final class Options
         $resolver->setAllowedValues('context_lines', \Closure::fromCallable([$this, 'validateContextLinesOption']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
+        $resolver->setNormalizer('tags', static function (SymfonyOptions $options, array $value): array {
+            if (!empty($value)) {
+                @trigger_error('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.', \E_USER_DEPRECATED);
+            }
+
+            return $value;
+        });
 
         $resolver->setNormalizer('prefixes', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);

--- a/src/Options.php
+++ b/src/Options.php
@@ -700,8 +700,8 @@ final class Options
     public function setDefaultPIIHeaders(array $headers)
     {
         foreach ($headers as $header) {
-            if (!is_string($header)) {
-                throw new \InvalidArgumentException("Headers must be strings.");
+            if (!\is_string($header)) {
+                throw new \InvalidArgumentException('Headers must be strings.');
             }
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -697,6 +697,11 @@ final class Options
         return $this->options['default_pii_headers'];
     }
 
+    /**
+     * Set the headers to be sanitized when 'send_default_pii' is false.
+     *
+     * @param array<string> $headers
+     */
     public function setDefaultPIIHeaders(array $headers)
     {
         foreach ($headers as $header) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -352,7 +352,7 @@ final class Options
      * Gets a callback that will be invoked before an event is sent to the server.
      * If `null` is returned it won't be sent.
      *
-     * @psalm-return callable(Event): ?Event
+     * @psalm-return callable(Event, ?EventHint): ?Event
      */
     public function getBeforeSendCallback(): callable
     {
@@ -365,7 +365,7 @@ final class Options
      *
      * @param callable $callback The callable
      *
-     * @psalm-param callable(Event): ?Event $callback
+     * @psalm-param callable(Event, ?EventHint): ?Event $callback
      */
     public function setBeforeSendCallback(callable $callback): void
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -8,7 +8,6 @@ use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use function is_string;
 
 /**
  * Configuration container for the Sentry client.
@@ -702,7 +701,7 @@ final class Options
      *
      * @param array<string> $headers
      */
-    public function setDefaultPIIHeaders(array $headers)
+    public function setDefaultPIIHeaders(array $headers): void
     {
         foreach ($headers as $header) {
             if (!\is_string($header)) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -8,6 +8,7 @@ use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use function is_string;
 
 /**
  * Configuration container for the Sentry client.
@@ -687,6 +688,29 @@ final class Options
     }
 
     /**
+     * Array of headers to be sanitized as PII
+     *
+     * @return array<string>
+     */
+    public function getDefaultPIIHeaders()
+    {
+        return $this->options['default_pii_headers'];
+    }
+
+    public function setDefaultPIIHeaders(array $headers)
+    {
+        foreach ($headers as $header) {
+            if (!is_string($header)) {
+                throw new \InvalidArgumentException("Headers must be strings.");
+            }
+        }
+
+        $options = array_merge($this->options, ['default_pii_headers' => $headers]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -729,6 +753,7 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
+            'default_pii_headers' => ['authorization', 'cookie', 'set-cookie', 'remote_addr'],
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -89,24 +89,24 @@ final class Severity
     public static function fromError(int $severity): self
     {
         switch ($severity) {
-             case E_DEPRECATED:
-             case E_USER_DEPRECATED:
-             case E_WARNING:
-             case E_USER_WARNING:
+             case \E_DEPRECATED:
+             case \E_USER_DEPRECATED:
+             case \E_WARNING:
+             case \E_USER_WARNING:
                  return self::warning();
-             case E_ERROR:
-             case E_PARSE:
-             case E_CORE_ERROR:
-             case E_CORE_WARNING:
-             case E_COMPILE_ERROR:
-             case E_COMPILE_WARNING:
+             case \E_ERROR:
+             case \E_PARSE:
+             case \E_CORE_ERROR:
+             case \E_CORE_WARNING:
+             case \E_COMPILE_ERROR:
+             case \E_COMPILE_WARNING:
                  return self::fatal();
-             case E_RECOVERABLE_ERROR:
-             case E_USER_ERROR:
+             case \E_RECOVERABLE_ERROR:
+             case \E_USER_ERROR:
                  return self::error();
-             case E_NOTICE:
-             case E_USER_NOTICE:
-             case E_STRICT:
+             case \E_NOTICE:
+             case \E_USER_NOTICE:
+             case \E_STRICT:
                  return self::info();
              default:
                  return self::error();

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -116,12 +116,13 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?EventId
+    public function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
     {
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureMessage($message, $level, $this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureMessage($message, $level, $this->getScope(), $hint);
         }
 
         return null;
@@ -130,12 +131,13 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception): ?EventId
+    public function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
     {
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureException($exception, $this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureException($exception, $this->getScope(), $hint);
         }
 
         return null;
@@ -158,12 +160,13 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(): ?EventId
+    public function captureLastError(?EventHint $hint = null): ?EventId
     {
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureLastError($this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureLastError($this->getScope(), $hint);
         }
 
         return null;
@@ -213,15 +216,11 @@ final class Hub implements HubInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array<string, mixed> $customSamplingContext Additional context that will be passed to the {@see SamplingContext}
      */
-    public function startTransaction(TransactionContext $context): Transaction
+    public function startTransaction(TransactionContext $context, array $customSamplingContext = []): Transaction
     {
-        $customSamplingContext = null;
-
-        if (\func_num_args() > 1) {
-            $customSamplingContext = func_get_arg(1);
-        }
-
         $transaction = new Transaction($context, $this);
         $client = $this->getClient();
         $options = null !== $client ? $client->getOptions() : null;

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -75,17 +75,19 @@ interface HubInterface
     /**
      * Captures a message event and sends it to Sentry.
      *
-     * @param string   $message The message
-     * @param Severity $level   The severity level of the message
+     * @param string         $message The message
+     * @param Severity|null  $level   The severity level of the message
+     * @param EventHint|null $hint    Object that can contain additional information about the event
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?EventId;
+    public function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures an exception event and sends it to Sentry.
      *
-     * @param \Throwable $exception The exception
+     * @param \Throwable     $exception The exception
+     * @param EventHint|null $hint      Object that can contain additional information about the event
      */
-    public function captureException(\Throwable $exception): ?EventId;
+    public function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures a new event using the provided data.
@@ -97,8 +99,10 @@ interface HubInterface
 
     /**
      * Captures an event that logs the last occurred error.
+     *
+     * @param EventHint|null $hint Object that can contain additional information about the event
      */
-    public function captureLastError(): ?EventId;
+    public function captureLastError(/*?EventHint $hint = null*/): ?EventId;
 
     /**
      * Records a new breadcrumb which will be attached to future events. They
@@ -142,7 +146,7 @@ interface HubInterface
      * @param TransactionContext   $context               Properties of the new transaction
      * @param array<string, mixed> $customSamplingContext Additional context that will be passed to the {@see SamplingContext}
      */
-    public function startTransaction(TransactionContext $context): Transaction;
+    public function startTransaction(TransactionContext $context/*, array $customSamplingContext = []*/): Transaction;
 
     /**
      * Returns the transaction that is on the Hub.

--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -199,7 +199,7 @@ class SpanContext
      */
     public static function fromTraceparent(string $header)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 3.1 and will be removed in 4.0. Use TransactionContext::fromSentryTrace() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.1 and will be removed in 4.0. Use TransactionContext::fromSentryTrace() instead.', __METHOD__), \E_USER_DEPRECATED);
 
         /** @phpstan-ignore-next-line */ /** @psalm-suppress UnsafeInstantiation */
         $context = new static();

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -174,7 +174,7 @@ final class UserDataBag
      */
     public function setIpAddress(?string $ipAddress): void
     {
-        if (null !== $ipAddress && false === filter_var($ipAddress, FILTER_VALIDATE_IP)) {
+        if (null !== $ipAddress && false === filter_var($ipAddress, \FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value is not a valid IP address.', $ipAddress));
         }
 

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -28,11 +28,11 @@ final class JSON
      */
     public static function encode($data, int $options = 0, int $maxDepth = 512)
     {
-        $options |= JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
+        $options |= \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE;
 
         $encodedData = json_encode($data, $options, $maxDepth);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (\JSON_ERROR_NONE !== json_last_error()) {
             throw new JsonException(sprintf('Could not encode value into JSON format. Error was: "%s".', json_last_error_msg()));
         }
 
@@ -52,7 +52,7 @@ final class JSON
     {
         $decodedData = json_decode($data, true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (\JSON_ERROR_NONE !== json_last_error()) {
             throw new JsonException(sprintf('Could not decode value from JSON format. Error was: "%s".', json_last_error_msg()));
         }
 

--- a/src/Util/PHPVersion.php
+++ b/src/Util/PHPVersion.php
@@ -20,7 +20,7 @@ final class PHPVersion
      *
      * @param string $version The string to parse
      */
-    public static function parseVersion(string $version = PHP_VERSION): string
+    public static function parseVersion(string $version = \PHP_VERSION): string
     {
         if (!preg_match(self::VERSION_PARSING_REGEX, $version, $matches)) {
             return $version;

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,22 +22,26 @@ function init(array $options = []): void
 /**
  * Captures a message event and sends it to Sentry.
  *
- * @param string        $message The message
- * @param Severity|null $level   The severity level of the message
+ * @param string         $message The message
+ * @param Severity|null  $level   The severity level of the message
+ * @param EventHint|null $hint    Object that can contain additional information about the event
  */
-function captureMessage(string $message, ?Severity $level = null): ?EventId
+function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureMessage($message, $level);
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureMessage($message, $level, $hint);
 }
 
 /**
  * Captures an exception event and sends it to Sentry.
  *
- * @param \Throwable $exception The exception
+ * @param \Throwable     $exception The exception
+ * @param EventHint|null $hint      Object that can contain additional information about the event
  */
-function captureException(\Throwable $exception): ?EventId
+function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureException($exception);
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureException($exception, $hint);
 }
 
 /**
@@ -52,11 +56,14 @@ function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
 }
 
 /**
- * Logs the most recent error (obtained with {@link error_get_last}).
+ * Logs the most recent error (obtained with {@see error_get_last()}).
+ *
+ * @param EventHint|null $hint Object that can contain additional information about the event
  */
-function captureLastError(): ?EventId
+function captureLastError(?EventHint $hint = null): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureLastError();
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureLastError($hint);
 }
 
 /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -106,6 +106,28 @@ final class ClientTest extends TestCase
         $this->assertNotNull($client->captureMessage('foo', Severity::fatal()));
     }
 
+    public function testCaptureMessageWithEventHint(): void
+    {
+        $hint = new EventHint();
+        $hint->extra = ['foo' => 'bar'];
+
+        $beforeSendCallbackCalled = false;
+        $options = new Options([
+            'before_send' => function (Event $event, ?EventHint $hintArg) use ($hint, &$beforeSendCallbackCalled) {
+                $this->assertSame($hint, $hintArg);
+
+                $beforeSendCallbackCalled = true;
+
+                return null;
+            },
+        ]);
+
+        $client = new Client($options, $this->createMock(TransportInterface::class));
+        $client->captureMessage('foo', null, null, $hint);
+
+        $this->assertTrue($beforeSendCallbackCalled);
+    }
+
     public function testCaptureException(): void
     {
         $exception = new \Exception('Some foo error');
@@ -133,6 +155,46 @@ final class ClientTest extends TestCase
             ->getClient();
 
         $this->assertNotNull($client->captureException($exception));
+    }
+
+    /**
+     * @dataProvider captureExceptionWithEventHintDataProvider
+     */
+    public function testCaptureExceptionWithEventHint(EventHint $hint): void
+    {
+        $beforeSendCallbackCalled = false;
+        $exception = $hint->exception ?? new \Exception();
+
+        $options = new Options([
+            'before_send' => function (Event $event, ?EventHint $hintArg) use ($exception, $hint, &$beforeSendCallbackCalled) {
+                $this->assertSame($hint, $hintArg);
+                $this->assertSame($exception, $hintArg->exception);
+
+                $beforeSendCallbackCalled = true;
+
+                return null;
+            },
+        ]);
+
+        $client = new Client($options, $this->createMock(TransportInterface::class));
+        $client->captureException($exception, null, $hint);
+
+        $this->assertTrue($beforeSendCallbackCalled);
+    }
+
+    public function captureExceptionWithEventHintDataProvider(): \Generator
+    {
+        yield [
+            EventHint::fromArray([
+                'extra' => ['foo' => 'bar'],
+            ]),
+        ];
+
+        yield [
+            EventHint::fromArray([
+                'exception' => new \Exception('foo'),
+            ]),
+        ];
     }
 
     /**
@@ -188,6 +250,28 @@ final class ClientTest extends TestCase
             $event,
             $event,
         ];
+    }
+
+    public function testCaptureEventWithEventHint(): void
+    {
+        $hint = new EventHint();
+        $hint->extra = ['foo' => 'bar'];
+
+        $beforeSendCallbackCalled = false;
+        $options = new Options([
+            'before_send' => function (Event $event, ?EventHint $hintArg) use ($hint, &$beforeSendCallbackCalled) {
+                $this->assertSame($hint, $hintArg);
+
+                $beforeSendCallbackCalled = true;
+
+                return null;
+            },
+        ]);
+
+        $client = new Client($options, $this->createMock(TransportInterface::class));
+        $client->captureEvent(Event::createEvent(), $hint);
+
+        $this->assertTrue($beforeSendCallbackCalled);
     }
 
     /**
@@ -305,6 +389,33 @@ final class ClientTest extends TestCase
         $this->assertNotNull($client->captureLastError());
 
         error_clear_last();
+    }
+
+    public function testCaptureLastErrorWithEventHint(): void
+    {
+        $hint = new EventHint();
+        $hint->extra = ['foo' => 'bar'];
+
+        $beforeSendCallbackCalled = false;
+        $options = new Options([
+            'before_send' => function (Event $event, ?EventHint $hintArg) use ($hint, &$beforeSendCallbackCalled) {
+                $this->assertSame($hint, $hintArg);
+
+                $beforeSendCallbackCalled = true;
+
+                return null;
+            },
+        ]);
+
+        $client = new Client($options, $this->createMock(TransportInterface::class));
+
+        @trigger_error('foo', E_USER_NOTICE);
+
+        $client->captureLastError(null, $hint);
+
+        error_clear_last();
+
+        $this->assertTrue($beforeSendCallbackCalled);
     }
 
     public function testCaptureLastErrorDoesNothingWhenThereIsNoError(): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -409,7 +409,7 @@ final class ClientTest extends TestCase
 
         $client = new Client($options, $this->createMock(TransportInterface::class));
 
-        @trigger_error('foo', E_USER_NOTICE);
+        @trigger_error('foo', \E_USER_NOTICE);
 
         $client->captureLastError(null, $hint);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,9 +29,12 @@ use Sentry\Stacktrace;
 use Sentry\State\Scope;
 use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class ClientTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testConstructorSetupsIntegrations(): void
     {
         $integrationCalled = false;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -297,7 +297,7 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        @trigger_error('foo', E_USER_NOTICE);
+        @trigger_error('foo', \E_USER_NOTICE);
 
         $this->assertNotNull($client->captureLastError());
 
@@ -552,7 +552,7 @@ final class ClientTest extends TestCase
     public function testBuildWithErrorException(): void
     {
         $options = new Options();
-        $exception = new \ErrorException('testMessage', 0, E_USER_ERROR);
+        $exception = new \ErrorException('testMessage', 0, \E_USER_ERROR);
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -198,10 +198,14 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider captureEventDataProvider
      */
     public function testCaptureEvent(array $options, Event $event, Event $expectedEvent): void
     {
+        $this->expectDeprecation('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.');
+
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
             ->method('send')

--- a/tests/EventHintTest.php
+++ b/tests/EventHintTest.php
@@ -21,30 +21,40 @@ final class EventHintTest extends TestCase
         $hint = EventHint::fromArray([
             'exception' => $exception,
             'stacktrace' => $stacktrace,
+            'extra' => ['foo' => 'bar'],
         ]);
 
-        $this->assertEquals($exception, $hint->exception);
-        $this->assertEquals($stacktrace, $hint->stacktrace);
+        $this->assertSame($exception, $hint->exception);
+        $this->assertSame($stacktrace, $hint->stacktrace);
+        $this->assertSame(['foo' => 'bar'], $hint->extra);
     }
 
-    public function testThrowsExceptionOnInvalidKeyInArray(): void
+    /**
+     * @dataProvider createFromArrayWithInvalidValuesDataProvider
+     */
+    public function testCreateFromArrayWithInvalidValues(array $hintData, string $expectedExceptionMessage): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
+        $this->expectExceptionMessage($expectedExceptionMessage);
 
-        EventHint::fromArray([
-            'missing_property' => 'some value',
-        ]);
+        EventHint::fromArray($hintData);
     }
 
-    public function testThrowsExceptionOnInvalidKeyInArrayWhenValidKeyIsPresent(): void
+    public function createFromArrayWithInvalidValuesDataProvider(): \Generator
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
+        yield [
+            ['exception' => 'foo'],
+            'The value of the "exception" field must be an instance of a class implementing the "Throwable" interface. Got: "string".',
+        ];
 
-        EventHint::fromArray([
-            'exception' => new \Exception(),
-            'missing_property' => 'some value',
-        ]);
+        yield [
+            ['stacktrace' => 'foo'],
+            'The value of the "stacktrace" field must be an instance of the "Sentry\\Stacktrace" class. Got: "string".',
+        ];
+
+        yield [
+            ['extra' => 'foo'],
+            'The value of the "extra" field must be an array. Got: "string".',
+        ];
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -9,12 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\Severity;
+use Sentry\State\HubInterface;
 use Sentry\State\Scope;
-use Sentry\Tracing\SamplingContext;
+use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use function Sentry\addBreadcrumb;
 use function Sentry\captureEvent;
@@ -35,70 +37,141 @@ final class FunctionsTest extends TestCase
         $this->assertNotNull(SentrySdk::getCurrentHub()->getClient());
     }
 
-    public function testCaptureMessage(): void
+    /**
+     * @dataProvider captureMessageDataProvider
+     */
+    public function testCaptureMessage(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureMessage')
-            ->with('foo', Severity::debug())
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($eventId, captureMessage('foo', Severity::debug()));
+        $this->assertSame($eventId, captureMessage(...$functionCallArgs));
     }
 
-    public function testCaptureException(): void
+    public function captureMessageDataProvider(): \Generator
+    {
+        yield [
+            [
+                'foo',
+                Severity::debug(),
+            ],
+            [
+                'foo',
+                Severity::debug(),
+                null,
+            ],
+        ];
+
+        yield [
+            [
+                'foo',
+                Severity::debug(),
+                new EventHint(),
+            ],
+            [
+                'foo',
+                Severity::debug(),
+                new EventHint(),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider captureExceptionDataProvider
+     */
+    public function testCaptureException(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
-        $exception = new \RuntimeException('foo');
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureException')
-            ->with($exception)
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($eventId, captureException($exception));
+        $this->assertSame($eventId, captureException(...$functionCallArgs));
+    }
+
+    public function captureExceptionDataProvider(): \Generator
+    {
+        yield [
+            [
+                new \Exception('foo'),
+            ],
+            [
+                new \Exception('foo'),
+                null,
+            ],
+        ];
+
+        yield [
+            [
+                new \Exception('foo'),
+                new EventHint(),
+            ],
+            [
+                new \Exception('foo'),
+                new EventHint(),
+            ],
+        ];
     }
 
     public function testCaptureEvent(): void
     {
         $event = Event::createEvent();
+        $hint = new EventHint();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureEvent')
-            ->with($event)
+            ->with($event, $hint)
             ->willReturn($event->getId());
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($event->getId(), captureEvent($event));
+        $this->assertSame($event->getId(), captureEvent($event, $hint));
     }
 
-    public function testCaptureLastError()
+    /**
+     * @dataProvider captureLastErrorDataProvider
+     */
+    public function testCaptureLastError(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureLastError')
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
         @trigger_error('foo', E_USER_NOTICE);
 
-        $this->assertSame($eventId, captureLastError());
+        $this->assertSame($eventId, captureLastError(...$functionCallArgs));
+    }
+
+    public function captureLastErrorDataProvider(): \Generator
+    {
+        yield [
+            [],
+            [null],
+        ];
+
+        yield [
+            [new EventHint()],
+            [new EventHint()],
+        ];
     }
 
     public function testAddBreadcrumb(): void
@@ -147,23 +220,17 @@ final class FunctionsTest extends TestCase
     public function testStartTransaction(): void
     {
         $transactionContext = new TransactionContext('foo');
+        $transaction = new Transaction($transactionContext);
         $customSamplingContext = ['foo' => 'bar'];
 
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('getOptions')
-            ->willReturn(new Options([
-                'traces_sampler' => function (SamplingContext $samplingContext) use ($customSamplingContext): float {
-                    $this->assertSame($customSamplingContext, $samplingContext->getAdditionalContext());
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
+            ->method('startTransaction')
+            ->with($transactionContext, $customSamplingContext)
+            ->willReturn($transaction);
 
-                    return 0.0;
-                },
-            ]));
+        SentrySdk::setCurrentHub($hub);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
-
-        $transaction = startTransaction($transactionContext, $customSamplingContext);
-
-        $this->assertSame($transactionContext->getName(), $transaction->getName());
+        $this->assertSame($transaction, startTransaction($transactionContext, $customSamplingContext));
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -96,7 +96,7 @@ final class FunctionsTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        @trigger_error('foo', E_USER_NOTICE);
+        @trigger_error('foo', \E_USER_NOTICE);
 
         $this->assertSame($eventId, captureLastError());
     }

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -60,7 +60,7 @@ final class HttpClientFactoryTest extends TestCase
 
         yield [
             true,
-            gzcompress('foo bar', -1, ZLIB_ENCODING_GZIP),
+            gzcompress('foo bar', -1, \ZLIB_ENCODING_GZIP),
         ];
     }
 

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -28,7 +28,7 @@ final class GzipEncoderPluginTest extends TestCase
             $request,
             function (RequestInterface $requestArg) use ($expectedPromise): PromiseInterface {
                 $this->assertSame('gzip', $requestArg->getHeaderLine('Content-Encoding'));
-                $this->assertSame(gzcompress('foo', -1, ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
+                $this->assertSame(gzcompress('foo', -1, \ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
 
                 return $expectedPromise;
             },

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -6,7 +6,6 @@ namespace Sentry\Tests\Integration;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\UploadedFile;
-use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -69,7 +68,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => true,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('GET', 'http://www.example.com/foo'))
                 ->withCookieParams(['foo' => 'bar']),
             [
                 'url' => 'http://www.example.com/foo',
@@ -89,7 +88,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => false,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('GET', 'http://www.example.com/foo'))
                 ->withCookieParams(['foo' => 'bar']),
             [
                 'url' => 'http://www.example.com/foo',
@@ -106,7 +105,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => true,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com:1234/foo'))),
+            (new ServerRequest('GET', 'http://www.example.com:1234/foo')),
             [
                 'url' => 'http://www.example.com:1234/foo',
                 'method' => 'GET',
@@ -123,7 +122,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => false,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com:1234/foo'))),
+            (new ServerRequest('GET', 'http://www.example.com:1234/foo')),
             [
                 'url' => 'http://www.example.com:1234/foo',
                 'method' => 'GET',
@@ -139,7 +138,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => true,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com/foo?foo=bar&bar=baz'), [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
+            (new ServerRequest('GET', 'http://www.example.com/foo?foo=bar&bar=baz', [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
                 ->withHeader('Host', 'www.example.com')
                 ->withHeader('Authorization', 'foo')
                 ->withHeader('Cookie', 'bar')
@@ -167,7 +166,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => false,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com/foo?foo=bar&bar=baz'), [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
+            (new ServerRequest('GET', 'http://www.example.com/foo?foo=bar&bar=baz', [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
                 ->withHeader('Host', 'www.example.com')
                 ->withHeader('Authorization', 'foo')
                 ->withHeader('Cookie', 'bar')
@@ -189,9 +188,30 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
+                'send_default_pii' => false,
+                'integrations' => [
+                    new RequestIntegration(null, ['pii_sanitize_headers' => ['aUthOrIzAtIoN']]),
+                ],
+            ],
+            (new ServerRequest('GET', 'http://www.example.com', [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
+                ->withHeader('Authorization', 'foo'),
+            [
+                'url' => 'http://www.example.com',
+                'method' => 'GET',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Authorization' => ['[Filtered]'],
+                ],
+            ],
+            null,
+            null,
+        ];
+
+        yield [
+            [
                 'max_request_body_size' => 'none',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', '3')
                 ->withBody(Utils::streamFor('foo')),
             [
@@ -210,7 +230,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'small',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', 10 ** 3)
                 ->withBody(Utils::streamFor('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at placerat est. Donec maximus odio augue, vitae bibendum nisi euismod nec. Nunc vel velit ligula. Ut non ultricies magna, non condimentum turpis. Donec pellentesque id nunc at facilisis. Sed fermentum ultricies nunc, id posuere ex ullamcorper quis. Sed varius tincidunt nulla, id varius nulla interdum sit amet. Pellentesque molestie sapien at mi tristique consequat. Nullam id eleifend arcu. Vivamus sed placerat neque. Ut sapien magna, elementum in euismod pretium, rhoncus vitae augue. Nam ullamcorper dui et tortor semper, eu feugiat elit faucibus. Curabitur vel auctor odio. Phasellus vestibulum ullamcorper dictum. Suspendisse fringilla, ipsum bibendum venenatis vulputate, nunc orci facilisis leo, commodo finibus mi arcu in turpis. Mauris ut ultrices est. Nam quis purus ut nulla interdum ornare. Proin in tellus egestas, commodo magna porta, consequat justo. Vivamus in convallis odio. Pellentesque porttitor, urna non gravida.')),
             [
@@ -230,7 +250,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'small',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', (string) (10 ** 3))
                 ->withParsedBody([
                     'foo' => 'foo value',
@@ -256,7 +276,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'small',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', (string) (10 ** 3 + 1))
                 ->withParsedBody([
                     'foo' => 'foo value',
@@ -278,7 +298,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'medium',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', (string) (10 ** 4))
                 ->withParsedBody([
                     'foo' => 'foo value',
@@ -304,7 +324,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'medium',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', (string) (10 ** 4 + 1))
                 ->withParsedBody([
                     'foo' => 'foo value',
@@ -326,7 +346,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'always',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Length', '444')
                 ->withUploadedFiles([
                     'foo' => [
@@ -364,7 +384,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'always',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Type', 'application/json')
                 ->withHeader('Content-Length', '13')
                 ->withBody(Utils::streamFor('{"foo":"bar"}')),
@@ -388,7 +408,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'max_request_body_size' => 'always',
             ],
-            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Type', 'application/json')
                 ->withBody(Utils::streamFor('{"foo":"bar"}')),
             [

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -178,6 +178,10 @@ final class RequestIntegrationTest extends TestCase
                 'query_string' => 'foo=bar&bar=baz',
                 'headers' => [
                     'Host' => ['www.example.com'],
+                    'Authorization' => ['[Filtered]'],
+                    'Cookie' => ['[Filtered]'],
+                    'Set-Cookie' => ['[Filtered]'],
+                    'REMOTE_ADDR' => ['[Filtered]'],
                 ],
             ],
             null,

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -167,7 +167,7 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => false,
             ],
-            (new ServerRequest('GET', new Uri('http://www.example.com/foo?foo=bar&bar=baz'), ['REMOTE_ADDR' => '127.0.0.1']))
+            (new ServerRequest('GET', new Uri('http://www.example.com/foo?foo=bar&bar=baz'), [], null, '1.1', ['REMOTE_ADDR' => '127.0.0.1']))
                 ->withHeader('Host', 'www.example.com')
                 ->withHeader('Authorization', 'foo')
                 ->withHeader('Cookie', 'bar')
@@ -177,7 +177,6 @@ final class RequestIntegrationTest extends TestCase
                 'method' => 'GET',
                 'query_string' => 'foo=bar&bar=baz',
                 'headers' => [
-                    'REMOTE_ADDR' => ['[Filtered]'],
                     'Host' => ['www.example.com'],
                     'Authorization' => ['[Filtered]'],
                     'Cookie' => ['[Filtered]'],

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -178,10 +178,10 @@ final class RequestIntegrationTest extends TestCase
                 'query_string' => 'foo=bar&bar=baz',
                 'headers' => [
                     'Host' => ['www.example.com'],
+                    'REMOTE_ADDR' => ['[Filtered]'],
                     'Authorization' => ['[Filtered]'],
                     'Cookie' => ['[Filtered]'],
                     'Set-Cookie' => ['[Filtered]'],
-                    'REMOTE_ADDR' => ['[Filtered]'],
                 ],
             ],
             null,

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -327,8 +327,8 @@ final class RequestIntegrationTest extends TestCase
                 ->withHeader('Content-Length', '444')
                 ->withUploadedFiles([
                     'foo' => [
-                        new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
-                        new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
+                        new UploadedFile('foo content', 123, \UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
+                        new UploadedFile('bar content', 321, \UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
                     ],
                 ]),
             [

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -177,8 +177,8 @@ final class RequestIntegrationTest extends TestCase
                 'method' => 'GET',
                 'query_string' => 'foo=bar&bar=baz',
                 'headers' => [
-                    'Host' => ['www.example.com'],
                     'REMOTE_ADDR' => ['[Filtered]'],
+                    'Host' => ['www.example.com'],
                     'Authorization' => ['[Filtered]'],
                     'Cookie' => ['[Filtered]'],
                     'Set-Cookie' => ['[Filtered]'],

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,63 +7,289 @@ namespace Sentry\Tests;
 use PHPUnit\Framework\TestCase;
 use Sentry\Dsn;
 use Sentry\Options;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
-    /**
-     * @dataProvider optionsDataProvider
-     */
-    public function testConstructor($option, $value, $getterMethod): void
-    {
-        $configuration = new Options([$option => $value]);
-
-        $this->assertEquals($value, $configuration->$getterMethod());
-    }
+    use ExpectDeprecationTrait;
 
     /**
+     * @group legacy
+     *
      * @dataProvider optionsDataProvider
      */
-    public function testGettersAndSetters(string $option, $value, string $getterMethod, ?string $setterMethod = null): void
-    {
-        $configuration = new Options();
-
-        if (null !== $setterMethod) {
-            $configuration->$setterMethod($value);
+    public function testConstructor(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage
+    ): void {
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
         }
 
-        $this->assertEquals($value, $configuration->$getterMethod());
+        $options = new Options([$option => $value]);
+
+        $this->assertSame($value, $options->$getterMethod());
     }
 
-    public function optionsDataProvider(): array
+    /**
+     * @group legacy
+     *
+     * @dataProvider optionsDataProvider
+     */
+    public function testGettersAndSetters(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage,
+        ?string $expectedSetterDeprecationMessage
+    ): void {
+        if (null !== $expectedSetterDeprecationMessage) {
+            $this->expectDeprecation($expectedSetterDeprecationMessage);
+        }
+
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
+        }
+
+        $options = new Options();
+
+        if (null !== $setterMethod) {
+            $options->$setterMethod($value);
+        }
+
+        $this->assertSame($value, $options->$getterMethod());
+    }
+
+    public function optionsDataProvider(): \Generator
     {
-        return [
-            ['send_attempts', 1, 'getSendAttempts', 'setSendAttempts'],
-            ['prefixes', ['foo', 'bar'], 'getPrefixes', 'setPrefixes'],
-            ['sample_rate', 0.5, 'getSampleRate', 'setSampleRate'],
-            ['traces_sample_rate', 0.5, 'getTracesSampleRate', 'setTracesSampleRate'],
-            ['traces_sampler', static function (): void {}, 'getTracesSampler', 'setTracesSampler'],
-            ['attach_stacktrace', false, 'shouldAttachStacktrace', 'setAttachStacktrace'],
-            ['context_lines', 3, 'getContextLines', 'setContextLines'],
-            ['enable_compression', false, 'isCompressionEnabled', 'setEnableCompression'],
-            ['environment', 'foo', 'getEnvironment', 'setEnvironment'],
-            ['in_app_exclude', ['foo', 'bar'], 'getInAppExcludedPaths', 'setInAppExcludedPaths'],
-            ['in_app_include', ['foo', 'bar'], 'getInAppIncludedPaths', 'setInAppIncludedPaths'],
-            ['logger', 'foo', 'getLogger', 'setLogger'],
-            ['release', 'dev', 'getRelease', 'setRelease'],
-            ['server_name', 'foo', 'getServerName', 'setServerName'],
-            ['tags', ['foo', 'bar'], 'getTags', 'setTags'],
-            ['error_types', 0, 'getErrorTypes', 'setErrorTypes'],
-            ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
-            ['before_send', static function (): void {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
-            ['before_breadcrumb', static function (): void {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
-            ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
-            ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
-            ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
-            ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
-            ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
-            ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
-            ['default_pii_headers', ['foo', 'bar'], 'getDefaultPIIHeaders', 'setDefaultPIIHeaders'],
+        yield [
+            'send_attempts',
+            1,
+            'getSendAttempts',
+            'setSendAttempts',
+            null,
+            null,
+        ];
+
+        yield [
+            'prefixes',
+            ['foo', 'bar'],
+            'getPrefixes',
+            'setPrefixes',
+            null,
+            null,
+        ];
+
+        yield [
+            'sample_rate',
+            0.5,
+            'getSampleRate',
+            'setSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sample_rate',
+            0.5,
+            'getTracesSampleRate',
+            'setTracesSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sampler',
+            static function (): void {},
+            'getTracesSampler',
+            'setTracesSampler',
+            null,
+            null,
+        ];
+
+        yield [
+            'attach_stacktrace',
+            false,
+            'shouldAttachStacktrace',
+            'setAttachStacktrace',
+            null,
+            null,
+        ];
+
+        yield [
+            'context_lines',
+            3,
+            'getContextLines',
+            'setContextLines',
+            null,
+            null,
+        ];
+
+        yield [
+            'enable_compression',
+            false,
+            'isCompressionEnabled',
+            'setEnableCompression',
+            null,
+            null,
+        ];
+
+        yield [
+            'environment',
+            'foo',
+            'getEnvironment',
+            'setEnvironment',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_exclude',
+            ['foo', 'bar'],
+            'getInAppExcludedPaths',
+            'setInAppExcludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_include',
+            ['foo', 'bar'],
+            'getInAppIncludedPaths',
+            'setInAppIncludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'logger',
+            'foo',
+            'getLogger',
+            'setLogger',
+            'Method Sentry\\Options::getLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+        ];
+
+        yield [
+            'release',
+            'dev',
+            'getRelease',
+            'setRelease',
+            null,
+            null,
+        ];
+
+        yield [
+            'server_name',
+            'foo',
+            'getServerName',
+            'setServerName',
+            null,
+            null,
+        ];
+
+        yield [
+            'tags',
+            ['foo', 'bar'],
+            'getTags',
+            'setTags',
+            'Method Sentry\\Options::getTags() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setTags() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.',
+        ];
+
+        yield [
+            'error_types',
+            0,
+            'getErrorTypes',
+            'setErrorTypes',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_breadcrumbs',
+            50,
+            'getMaxBreadcrumbs',
+            'setMaxBreadcrumbs',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_send',
+            static function (): void {},
+            'getBeforeSendCallback',
+            'setBeforeSendCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_breadcrumb',
+            static function (): void {},
+            'getBeforeBreadcrumbCallback',
+            'setBeforeBreadcrumbCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'send_default_pii',
+            true,
+            'shouldSendDefaultPii',
+            'setSendDefaultPii',
+            null,
+            null,
+        ];
+
+        yield [
+            'default_integrations',
+            false,
+            'hasDefaultIntegrations',
+            'setDefaultIntegrations',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_value_length',
+            50,
+            'getMaxValueLength',
+            'setMaxValueLength',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_proxy',
+            '127.0.0.1',
+            'getHttpProxy',
+            'setHttpProxy',
+            null,
+            null,
+        ];
+
+        yield [
+            'capture_silenced_errors',
+            true,
+            'shouldCaptureSilencedErrors',
+            'setCaptureSilencedErrors',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_request_body_size',
+            'small',
+            'getMaxRequestBodySize',
+            'setMaxRequestBodySize',
+            null,
+            null,
         ];
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,62 +7,289 @@ namespace Sentry\Tests;
 use PHPUnit\Framework\TestCase;
 use Sentry\Dsn;
 use Sentry\Options;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
-    /**
-     * @dataProvider optionsDataProvider
-     */
-    public function testConstructor($option, $value, $getterMethod): void
-    {
-        $configuration = new Options([$option => $value]);
-
-        $this->assertEquals($value, $configuration->$getterMethod());
-    }
+    use ExpectDeprecationTrait;
 
     /**
+     * @group legacy
+     *
      * @dataProvider optionsDataProvider
      */
-    public function testGettersAndSetters(string $option, $value, string $getterMethod, ?string $setterMethod = null): void
-    {
-        $configuration = new Options();
-
-        if (null !== $setterMethod) {
-            $configuration->$setterMethod($value);
+    public function testConstructor(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage
+    ): void {
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
         }
 
-        $this->assertEquals($value, $configuration->$getterMethod());
+        $options = new Options([$option => $value]);
+
+        $this->assertSame($value, $options->$getterMethod());
     }
 
-    public function optionsDataProvider(): array
+    /**
+     * @group legacy
+     *
+     * @dataProvider optionsDataProvider
+     */
+    public function testGettersAndSetters(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage,
+        ?string $expectedSetterDeprecationMessage
+    ): void {
+        if (null !== $expectedSetterDeprecationMessage) {
+            $this->expectDeprecation($expectedSetterDeprecationMessage);
+        }
+
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
+        }
+
+        $options = new Options();
+
+        if (null !== $setterMethod) {
+            $options->$setterMethod($value);
+        }
+
+        $this->assertSame($value, $options->$getterMethod());
+    }
+
+    public function optionsDataProvider(): \Generator
     {
-        return [
-            ['send_attempts', 1, 'getSendAttempts', 'setSendAttempts'],
-            ['prefixes', ['foo', 'bar'], 'getPrefixes', 'setPrefixes'],
-            ['sample_rate', 0.5, 'getSampleRate', 'setSampleRate'],
-            ['traces_sample_rate', 0.5, 'getTracesSampleRate', 'setTracesSampleRate'],
-            ['traces_sampler', static function (): void {}, 'getTracesSampler', 'setTracesSampler'],
-            ['attach_stacktrace', false, 'shouldAttachStacktrace', 'setAttachStacktrace'],
-            ['context_lines', 3, 'getContextLines', 'setContextLines'],
-            ['enable_compression', false, 'isCompressionEnabled', 'setEnableCompression'],
-            ['environment', 'foo', 'getEnvironment', 'setEnvironment'],
-            ['in_app_exclude', ['foo', 'bar'], 'getInAppExcludedPaths', 'setInAppExcludedPaths'],
-            ['in_app_include', ['foo', 'bar'], 'getInAppIncludedPaths', 'setInAppIncludedPaths'],
-            ['logger', 'foo', 'getLogger', 'setLogger'],
-            ['release', 'dev', 'getRelease', 'setRelease'],
-            ['server_name', 'foo', 'getServerName', 'setServerName'],
-            ['tags', ['foo', 'bar'], 'getTags', 'setTags'],
-            ['error_types', 0, 'getErrorTypes', 'setErrorTypes'],
-            ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
-            ['before_send', static function (): void {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
-            ['before_breadcrumb', static function (): void {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
-            ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
-            ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
-            ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
-            ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
-            ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
-            ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
+        yield [
+            'send_attempts',
+            1,
+            'getSendAttempts',
+            'setSendAttempts',
+            null,
+            null,
+        ];
+
+        yield [
+            'prefixes',
+            ['foo', 'bar'],
+            'getPrefixes',
+            'setPrefixes',
+            null,
+            null,
+        ];
+
+        yield [
+            'sample_rate',
+            0.5,
+            'getSampleRate',
+            'setSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sample_rate',
+            0.5,
+            'getTracesSampleRate',
+            'setTracesSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sampler',
+            static function (): void {},
+            'getTracesSampler',
+            'setTracesSampler',
+            null,
+            null,
+        ];
+
+        yield [
+            'attach_stacktrace',
+            false,
+            'shouldAttachStacktrace',
+            'setAttachStacktrace',
+            null,
+            null,
+        ];
+
+        yield [
+            'context_lines',
+            3,
+            'getContextLines',
+            'setContextLines',
+            null,
+            null,
+        ];
+
+        yield [
+            'enable_compression',
+            false,
+            'isCompressionEnabled',
+            'setEnableCompression',
+            null,
+            null,
+        ];
+
+        yield [
+            'environment',
+            'foo',
+            'getEnvironment',
+            'setEnvironment',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_exclude',
+            ['foo', 'bar'],
+            'getInAppExcludedPaths',
+            'setInAppExcludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_include',
+            ['foo', 'bar'],
+            'getInAppIncludedPaths',
+            'setInAppIncludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'logger',
+            'foo',
+            'getLogger',
+            'setLogger',
+            'Method Sentry\\Options::getLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+        ];
+
+        yield [
+            'release',
+            'dev',
+            'getRelease',
+            'setRelease',
+            null,
+            null,
+        ];
+
+        yield [
+            'server_name',
+            'foo',
+            'getServerName',
+            'setServerName',
+            null,
+            null,
+        ];
+
+        yield [
+            'tags',
+            ['foo', 'bar'],
+            'getTags',
+            'setTags',
+            null,
+            null,
+        ];
+
+        yield [
+            'error_types',
+            0,
+            'getErrorTypes',
+            'setErrorTypes',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_breadcrumbs',
+            50,
+            'getMaxBreadcrumbs',
+            'setMaxBreadcrumbs',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_send',
+            static function (): void {},
+            'getBeforeSendCallback',
+            'setBeforeSendCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_breadcrumb',
+            static function (): void {},
+            'getBeforeBreadcrumbCallback',
+            'setBeforeBreadcrumbCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'send_default_pii',
+            true,
+            'shouldSendDefaultPii',
+            'setSendDefaultPii',
+            null,
+            null,
+        ];
+
+        yield [
+            'default_integrations',
+            false,
+            'hasDefaultIntegrations',
+            'setDefaultIntegrations',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_value_length',
+            50,
+            'getMaxValueLength',
+            'setMaxValueLength',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_proxy',
+            '127.0.0.1',
+            'getHttpProxy',
+            'setHttpProxy',
+            null,
+            null,
+        ];
+
+        yield [
+            'capture_silenced_errors',
+            true,
+            'shouldCaptureSilencedErrors',
+            'setCaptureSilencedErrors',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_request_body_size',
+            'small',
+            'getMaxRequestBodySize',
+            'setMaxRequestBodySize',
+            null,
+            null,
         ];
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,289 +7,63 @@ namespace Sentry\Tests;
 use PHPUnit\Framework\TestCase;
 use Sentry\Dsn;
 use Sentry\Options;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
-     * @group legacy
-     *
      * @dataProvider optionsDataProvider
      */
-    public function testConstructor(
-        string $option,
-        $value,
-        string $getterMethod,
-        ?string $setterMethod,
-        ?string $expectedGetterDeprecationMessage
-    ): void {
-        if (null !== $expectedGetterDeprecationMessage) {
-            $this->expectDeprecation($expectedGetterDeprecationMessage);
-        }
+    public function testConstructor($option, $value, $getterMethod): void
+    {
+        $configuration = new Options([$option => $value]);
 
-        $options = new Options([$option => $value]);
-
-        $this->assertSame($value, $options->$getterMethod());
+        $this->assertEquals($value, $configuration->$getterMethod());
     }
 
     /**
-     * @group legacy
-     *
      * @dataProvider optionsDataProvider
      */
-    public function testGettersAndSetters(
-        string $option,
-        $value,
-        string $getterMethod,
-        ?string $setterMethod,
-        ?string $expectedGetterDeprecationMessage,
-        ?string $expectedSetterDeprecationMessage
-    ): void {
-        if (null !== $expectedSetterDeprecationMessage) {
-            $this->expectDeprecation($expectedSetterDeprecationMessage);
-        }
-
-        if (null !== $expectedGetterDeprecationMessage) {
-            $this->expectDeprecation($expectedGetterDeprecationMessage);
-        }
-
-        $options = new Options();
+    public function testGettersAndSetters(string $option, $value, string $getterMethod, ?string $setterMethod = null): void
+    {
+        $configuration = new Options();
 
         if (null !== $setterMethod) {
-            $options->$setterMethod($value);
+            $configuration->$setterMethod($value);
         }
 
-        $this->assertSame($value, $options->$getterMethod());
+        $this->assertEquals($value, $configuration->$getterMethod());
     }
 
-    public function optionsDataProvider(): \Generator
+    public function optionsDataProvider(): array
     {
-        yield [
-            'send_attempts',
-            1,
-            'getSendAttempts',
-            'setSendAttempts',
-            null,
-            null,
-        ];
-
-        yield [
-            'prefixes',
-            ['foo', 'bar'],
-            'getPrefixes',
-            'setPrefixes',
-            null,
-            null,
-        ];
-
-        yield [
-            'sample_rate',
-            0.5,
-            'getSampleRate',
-            'setSampleRate',
-            null,
-            null,
-        ];
-
-        yield [
-            'traces_sample_rate',
-            0.5,
-            'getTracesSampleRate',
-            'setTracesSampleRate',
-            null,
-            null,
-        ];
-
-        yield [
-            'traces_sampler',
-            static function (): void {},
-            'getTracesSampler',
-            'setTracesSampler',
-            null,
-            null,
-        ];
-
-        yield [
-            'attach_stacktrace',
-            false,
-            'shouldAttachStacktrace',
-            'setAttachStacktrace',
-            null,
-            null,
-        ];
-
-        yield [
-            'context_lines',
-            3,
-            'getContextLines',
-            'setContextLines',
-            null,
-            null,
-        ];
-
-        yield [
-            'enable_compression',
-            false,
-            'isCompressionEnabled',
-            'setEnableCompression',
-            null,
-            null,
-        ];
-
-        yield [
-            'environment',
-            'foo',
-            'getEnvironment',
-            'setEnvironment',
-            null,
-            null,
-        ];
-
-        yield [
-            'in_app_exclude',
-            ['foo', 'bar'],
-            'getInAppExcludedPaths',
-            'setInAppExcludedPaths',
-            null,
-            null,
-        ];
-
-        yield [
-            'in_app_include',
-            ['foo', 'bar'],
-            'getInAppIncludedPaths',
-            'setInAppIncludedPaths',
-            null,
-            null,
-        ];
-
-        yield [
-            'logger',
-            'foo',
-            'getLogger',
-            'setLogger',
-            'Method Sentry\\Options::getLogger() is deprecated since version 3.2 and will be removed in 4.0.',
-            'Method Sentry\\Options::setLogger() is deprecated since version 3.2 and will be removed in 4.0.',
-        ];
-
-        yield [
-            'release',
-            'dev',
-            'getRelease',
-            'setRelease',
-            null,
-            null,
-        ];
-
-        yield [
-            'server_name',
-            'foo',
-            'getServerName',
-            'setServerName',
-            null,
-            null,
-        ];
-
-        yield [
-            'tags',
-            ['foo', 'bar'],
-            'getTags',
-            'setTags',
-            'Method Sentry\\Options::getTags() is deprecated since version 3.2 and will be removed in 4.0.',
-            'Method Sentry\\Options::setTags() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.',
-        ];
-
-        yield [
-            'error_types',
-            0,
-            'getErrorTypes',
-            'setErrorTypes',
-            null,
-            null,
-        ];
-
-        yield [
-            'max_breadcrumbs',
-            50,
-            'getMaxBreadcrumbs',
-            'setMaxBreadcrumbs',
-            null,
-            null,
-        ];
-
-        yield [
-            'before_send',
-            static function (): void {},
-            'getBeforeSendCallback',
-            'setBeforeSendCallback',
-            null,
-            null,
-        ];
-
-        yield [
-            'before_breadcrumb',
-            static function (): void {},
-            'getBeforeBreadcrumbCallback',
-            'setBeforeBreadcrumbCallback',
-            null,
-            null,
-        ];
-
-        yield [
-            'send_default_pii',
-            true,
-            'shouldSendDefaultPii',
-            'setSendDefaultPii',
-            null,
-            null,
-        ];
-
-        yield [
-            'default_integrations',
-            false,
-            'hasDefaultIntegrations',
-            'setDefaultIntegrations',
-            null,
-            null,
-        ];
-
-        yield [
-            'max_value_length',
-            50,
-            'getMaxValueLength',
-            'setMaxValueLength',
-            null,
-            null,
-        ];
-
-        yield [
-            'http_proxy',
-            '127.0.0.1',
-            'getHttpProxy',
-            'setHttpProxy',
-            null,
-            null,
-        ];
-
-        yield [
-            'capture_silenced_errors',
-            true,
-            'shouldCaptureSilencedErrors',
-            'setCaptureSilencedErrors',
-            null,
-            null,
-        ];
-
-        yield [
-            'max_request_body_size',
-            'small',
-            'getMaxRequestBodySize',
-            'setMaxRequestBodySize',
-            null,
-            null,
+        return [
+            ['send_attempts', 1, 'getSendAttempts', 'setSendAttempts'],
+            ['prefixes', ['foo', 'bar'], 'getPrefixes', 'setPrefixes'],
+            ['sample_rate', 0.5, 'getSampleRate', 'setSampleRate'],
+            ['traces_sample_rate', 0.5, 'getTracesSampleRate', 'setTracesSampleRate'],
+            ['traces_sampler', static function (): void {}, 'getTracesSampler', 'setTracesSampler'],
+            ['attach_stacktrace', false, 'shouldAttachStacktrace', 'setAttachStacktrace'],
+            ['context_lines', 3, 'getContextLines', 'setContextLines'],
+            ['enable_compression', false, 'isCompressionEnabled', 'setEnableCompression'],
+            ['environment', 'foo', 'getEnvironment', 'setEnvironment'],
+            ['in_app_exclude', ['foo', 'bar'], 'getInAppExcludedPaths', 'setInAppExcludedPaths'],
+            ['in_app_include', ['foo', 'bar'], 'getInAppIncludedPaths', 'setInAppIncludedPaths'],
+            ['logger', 'foo', 'getLogger', 'setLogger'],
+            ['release', 'dev', 'getRelease', 'setRelease'],
+            ['server_name', 'foo', 'getServerName', 'setServerName'],
+            ['tags', ['foo', 'bar'], 'getTags', 'setTags'],
+            ['error_types', 0, 'getErrorTypes', 'setErrorTypes'],
+            ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
+            ['before_send', static function (): void {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
+            ['before_breadcrumb', static function (): void {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
+            ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
+            ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
+            ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
+            ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
+            ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
+            ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
+            ['default_pii_headers', ['foo', 'bar'], 'getDefaultPIIHeaders', 'setDefaultPIIHeaders'],
         ];
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -198,8 +198,8 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getTags',
             'setTags',
-            null,
-            null,
+            'Method Sentry\\Options::getTags() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setTags() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.',
         ];
 
         yield [

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -187,7 +187,7 @@ final class SerializerTest extends AbstractSerializerTest
 
         $this->assertSame('Прекратит {clipped}', $clipped);
         $this->assertNotNull(json_encode($clipped));
-        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertSame(\JSON_ERROR_NONE, json_last_error());
     }
 
     /**

--- a/tests/SeverityTest.php
+++ b/tests/SeverityTest.php
@@ -66,24 +66,24 @@ final class SeverityTest extends TestCase
     {
         return [
             // Warning
-            [E_DEPRECATED, 'warning'],
-            [E_USER_DEPRECATED, 'warning'],
-            [E_WARNING, 'warning'],
-            [E_USER_WARNING, 'warning'],
+            [\E_DEPRECATED, 'warning'],
+            [\E_USER_DEPRECATED, 'warning'],
+            [\E_WARNING, 'warning'],
+            [\E_USER_WARNING, 'warning'],
             // Fatal
-            [E_ERROR, 'fatal'],
-            [E_PARSE, 'fatal'],
-            [E_CORE_ERROR, 'fatal'],
-            [E_CORE_WARNING, 'fatal'],
-            [E_COMPILE_ERROR, 'fatal'],
-            [E_COMPILE_WARNING, 'fatal'],
+            [\E_ERROR, 'fatal'],
+            [\E_PARSE, 'fatal'],
+            [\E_CORE_ERROR, 'fatal'],
+            [\E_CORE_WARNING, 'fatal'],
+            [\E_COMPILE_ERROR, 'fatal'],
+            [\E_COMPILE_WARNING, 'fatal'],
             // Error
-            [E_RECOVERABLE_ERROR, 'error'],
-            [E_USER_ERROR, 'error'],
+            [\E_RECOVERABLE_ERROR, 'error'],
+            [\E_USER_ERROR, 'error'],
             // Info
-            [E_NOTICE, 'info'],
-            [E_USER_NOTICE, 'info'],
-            [E_STRICT, 'info'],
+            [\E_NOTICE, 'info'],
+            [\E_USER_NOTICE, 'info'],
+            [\E_STRICT, 'info'],
         ];
     }
 }

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -115,7 +115,7 @@ final class JSONTest extends TestCase
 
     public function testEncodeRespectsOptionsArgument(): void
     {
-        $this->assertSame('{}', JSON::encode([], JSON_FORCE_OBJECT));
+        $this->assertSame('{}', JSON::encode([], \JSON_FORCE_OBJECT));
     }
 
     /**


### PR DESCRIPTION
It's often extremely useful to know what headers were passed, even without the value.  We were trying to track down a rare bug with authentication and knowing if the Authentication header was being passed would have been incredibly useful.  There shouldn't really be any security concern with passing the redacted header keys.